### PR TITLE
Support Django 2.2 and stop RemovedInDjango30Warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,13 @@ To run the tests fully, you will need to install tox.
 History
 -------
 
+Pending
+~~~~~~~
+
+* Tested with Django 2.2.
+* Stop "RemovedInDjango30Warning: Remove the context parameter from
+  JSONField.from_db_value()." on Django 2.0+.
+
 1.1.0 (2019-03-16)
 ~~~~~~~~~~~~~~~~~~
 

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import json
 
+import django
 from django.core.exceptions import ValidationError
 from django.conf import settings
 from django.db import models
@@ -80,11 +81,16 @@ class JSONField(models.Field):
             return 'long'
         return 'text'
 
-    def from_db_value(self, value, expression, connection, context):
-        if value is None:
-            return None
-        return json.loads(value, **self.decoder_kwargs)
-
+    if django.VERSION > (2, 0):
+        def from_db_value(self, value, expression, connection):
+            if value is None:
+                return None
+            return   json.loads(value, **self.decoder_kwargs)
+    else:
+        def from_db_value(self, value, expression, connection, context):
+            if value is None:
+                return None
+            return json.loads(value, **self.decoder_kwargs)
 
     def get_db_prep_value(self, value, connection=None, prepared=None):
         return self.get_prep_value(value)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters = true
 envlist = py{27,34,35}-django{19,110,111}-{postgres,mysql,sqlite}
-          py{35,36}-django{20,21}-{postgres,mysql,sqlite}
+          py{35,36,37}-django{20,21,22}-{postgres,mysql,sqlite}
 
 [testenv]
 deps=
@@ -11,7 +11,7 @@ deps=
   django111: Django>=1.11,<2.0
   django20: Django>=2.0,<2.1
   django21: Django>=2.1,<2.2
-  djangotrunk: git+https://github.com/django/django.git
+  django22: Django>=2.2,<2.3
   postgres: psycopg2
   mysql: mysqlclient
 setenv=


### PR DESCRIPTION
* Add HISTORY note and update README
* Add 2.2 to tox testing grid
* Update `classifiers` in `setup.py`