### PR TITLE
Cast value to text on PostgreSQL if custom decoder is used

### DIFF
--- a/jsonfield/tests/jsonfield_test_app/models.py
+++ b/jsonfield/tests/jsonfield_test_app/models.py
@@ -1,3 +1,4 @@
+from django.contrib.postgres.fields import JSONField as PostgresJSONField
 from django.db import models
 from jsonfield.fields import JSONField
 
@@ -26,6 +27,14 @@ class BlankJSONFieldTestModel(models.Model):
 
 class CallableDefaultModel(models.Model):
     json = JSONField(default=lambda: {'x': 2})
+
+    class Meta:
+        app_label = 'jsonfield'
+
+
+class PostgresParallelModel(models.Model):
+    library_json = JSONField()
+    postgres_json = PostgresJSONField()
 
     class Meta:
         app_label = 'jsonfield'

--- a/jsonfield/tests/test_fields.py
+++ b/jsonfield/tests/test_fields.py
@@ -1,3 +1,6 @@
+from unittest import skipUnless
+
+from django.db import connection
 from django.core import serializers
 from django.test import TestCase as DjangoTestCase
 from django.utils.encoding import force_text
@@ -161,6 +164,13 @@ class JSONFieldTest(DjangoTestCase):
         serialized = serializers.serialize("json",
                                            JSONFieldTestModel.objects.all())
         self.assertIn('"json": "[\\"foo\\"]"', serialized)
+
+    @skipUnless(connection.vendor == 'postgresql', 'PostgreSQL-specific test')
+    def test_work_parallel_with_postgres_json_field(self):
+        data = {'foo': 'bar'}
+        obj = PostgresParallelModel.objects.create(library_json=data, postgres_json=data)
+        obj = PostgresParallelModel.objects.get(id=obj.id)
+        self.assertEqual(obj.library_json, obj.postgres_json)
 
 
 class SavingModelsTest(DjangoTestCase):


### PR DESCRIPTION
Fix #5.

Instead of registering a no-op `loads()` to avoid psycopg2's automatic decoding, we cast the value into `text`. As [the docs](http://initd.org/psycopg/docs/extras.html#json-adaptation) say, it is an efficient operation that doesn’t involve a copy.