### PR TITLE
Use CLOB instead  of LONG to store JSON data in Oracle

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -78,7 +78,7 @@ class JSONField(models.Field):
         if connection.vendor == 'mysql':
             return 'longtext'
         if connection.vendor == 'oracle':
-            return 'long'
+            return 'clob'
         return 'text'
 
     if django.VERSION > (2, 0):

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -83,12 +83,12 @@ class JSONField(models.Field):
 
     if django.VERSION > (2, 0):
         def from_db_value(self, value, expression, connection):
-            if value is None:
+            if value is None or value == '':
                 return None
             return   json.loads(value, **self.decoder_kwargs)
     else:
         def from_db_value(self, value, expression, connection, context):
-            if value is None:
+            if value is None or value == '':
                 return None
             return json.loads(value, **self.decoder_kwargs)
 

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -37,6 +37,7 @@ class JSONField(models.Field):
             self.encoder_kwargs['cls'] = _resolve_object_path(encoder_class)
 
         self.decoder_kwargs = dict(kwargs.pop('decoder_kwargs', getattr(settings, 'JSONFIELD_DECODER_KWARGS', {})))
+        self.custom_db_type = kwargs.pop('db_type', None)
         super(JSONField, self).__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
@@ -70,6 +71,8 @@ class JSONField(models.Field):
         return 'TextField'
 
     def db_type(self, connection):
+        if self.custom_db_type:
+            return self.custom_db_type
         if connection.vendor == 'postgresql':
             # Only do jsonb if in pg 9.4+
             if connection.pg_version >= 90400:

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -38,7 +38,6 @@ class JSONField(models.Field):
 
         self.decoder_kwargs = dict(kwargs.pop('decoder_kwargs', getattr(settings, 'JSONFIELD_DECODER_KWARGS', {})))
         super(JSONField, self).__init__(*args, **kwargs)
-        self.validate(self.get_default(), None)
 
     def formfield(self, **kwargs):
         defaults = {
@@ -49,6 +48,7 @@ class JSONField(models.Field):
         return super(JSONField, self).formfield(**defaults)
 
     def validate(self, value, model_instance):
+        super(JSONField, self).validate(value, model_instance)
         if not self.null and value is None:
             raise ValidationError(self.error_messages['null'])
         try:


### PR DESCRIPTION
The Oracle documentation reports (https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT1831):

Do not create tables with LONG columns. Use LOB columns (CLOB, NCLOB) instead. LONG columns are supported only for backward compatibility.

Oracle also recommends that you convert existing LONG columns to LOB columns. LOB columns are subject to far fewer restrictions than LONG columns. Further, LOB functionality is enhanced in every release, whereas LONG functionality has been static for several releases.

Other minor changes:
- Treat an empty string as None
- Allow for custom DB type to be set on field
- Use Django standard field validate in validation