### PR TITLE
Fix when using text db type with postgres

### DIFF
--- a/jsonfield/tests/jsonfield_test_app/models.py
+++ b/jsonfield/tests/jsonfield_test_app/models.py
@@ -34,6 +34,7 @@ class CallableDefaultModel(models.Model):
 
 class PostgresParallelModel(models.Model):
     library_json = JSONField()
+    postgres_text_json = JSONField(pg_text_type=True)
     postgres_json = PostgresJSONField()
 
     class Meta:

--- a/jsonfield/tests/test_fields.py
+++ b/jsonfield/tests/test_fields.py
@@ -168,9 +168,9 @@ class JSONFieldTest(DjangoTestCase):
     @skipUnless(connection.vendor == 'postgresql', 'PostgreSQL-specific test')
     def test_work_parallel_with_postgres_json_field(self):
         data = {'foo': 'bar'}
-        obj = PostgresParallelModel.objects.create(library_json=data, postgres_json=data)
+        obj = PostgresParallelModel.objects.create(library_json=data, postgres_text_json=data, postgres_json=data)
         obj = PostgresParallelModel.objects.get(id=obj.id)
-        self.assertEqual(obj.library_json, obj.postgres_json)
+        self.assertEqual(obj.library_json, obj.postgres_text_json, obj.postgres_json)
 
 
 class SavingModelsTest(DjangoTestCase):


### PR DESCRIPTION
Hello @adamchainz 

I came across some issues in quite old and large projects which use postgres and `JSONField` with text db type. Right now it's not possible to migrate those fields to jsonb, I think it could be a fairly common issue.