### PR TITLE
Warn users of similarly named jsonfield

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,13 @@ django-jsonfield
 **Maintenance mode only:** It is not recommended you use this library on new
 projects. See the (long) **History** section below for why and alternatives.
 
+**Naming clarification:** This project is released on Pypi under the name
+`django-jsonfield <https://pypi.org/project/django-jsonfield/>`_.
+It should not be confused with the Pypi package
+`jsonfield <https://pypi.org/project/jsonfield/>`_,
+which has also been called django-jsonfield by some.
+
+
 ----
 
 Cross-database JSON field for Django models.


### PR DESCRIPTION
The Pypi package `jsonfield` gives users a warning not to confuse it with the Pypi package `django-jsonfield`: https://pypi.org/project/jsonfield/2.1.1/ (edit: it looks like version 3.0.0 removed this warning)

It would be good if this package gave the same warning.

If you look at https://github.com/django-notifications/django-notifications/issues/269#issuecomment-585088457 , you can see that developers have been confusing the two. I think it is necessary for the documentation of both packages to warn users of the naming confusion.